### PR TITLE
Fix room creation/joining crashing if a zip needed to be opened

### DIFF
--- a/.idea/.idea.GamesToGo/.idea/modules.xml
+++ b/.idea/.idea.GamesToGo/.idea/modules.xml
@@ -2,6 +2,7 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/.idea.GamesToGo/.idea/GamesToGo.Android.iml" filepath="$PROJECT_DIR$/.idea/.idea.GamesToGo/.idea/GamesToGo.Android.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/.idea.GamesToGo/.idea/riderModule.iml" filepath="$PROJECT_DIR$/.idea/.idea.GamesToGo/.idea/riderModule.iml" />
     </modules>
   </component>

--- a/GamesToGo.Android/GamesToGo.Android.csproj
+++ b/GamesToGo.Android/GamesToGo.Android.csproj
@@ -43,6 +43,7 @@
     <EnableLLVM>false</EnableLLVM>
     <AndroidEnableProfiledAot>false</AndroidEnableProfiledAot>
     <BundleAssemblies>false</BundleAssemblies>
+    <AndroidSupportedAbis>armeabi-v7a;x86;arm64-v8a;x86_64</AndroidSupportedAbis>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>

--- a/GamesToGo.Android/MainActivity.cs
+++ b/GamesToGo.Android/MainActivity.cs
@@ -7,7 +7,7 @@ using osu.Framework.Android;
 
 namespace GamesToGo.Android
 {
-    [Activity(Theme = "@android:style/Theme.NoTitleBar", MainLauncher = true, ScreenOrientation = ScreenOrientation.Portrait, SupportsPictureInPicture = false, HardwareAccelerated = false)]
+    [Activity(Label = "GamesToGo", Theme = "@android:style/Theme.NoTitleBar", MainLauncher = true, ScreenOrientation = ScreenOrientation.Portrait, SupportsPictureInPicture = false, HardwareAccelerated = false)]
     public class MainActivity : AndroidGameActivity
     {
         protected override osu.Framework.Game CreateGame()

--- a/GamesToGo.Android/Properties/AndroidManifest.xml
+++ b/GamesToGo.Android/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.companyname.gamestogo.app" android:installLocation="auto">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="company.gamestogo.player" android:installLocation="auto">
 	<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="29" />
   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />

--- a/GamesToGo.Game/GamesToGo.Game.csproj
+++ b/GamesToGo.Game/GamesToGo.Game.csproj
@@ -10,7 +10,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DotNetZip" Version="1.15.0" />
     <PackageReference Include="ppy.osu.Framework" Version="2021.204.0" />
   </ItemGroup>
 

--- a/GamesToGo.Game/GamesToGoGame.cs
+++ b/GamesToGo.Game/GamesToGoGame.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using System.Threading.Tasks;
 using GamesToGo.Common.Online;
@@ -10,7 +11,6 @@ using GamesToGo.Common.Overlays;
 using GamesToGo.Game.Online.Models.RequestModel;
 using GamesToGo.Game.Online.Requests;
 using GamesToGo.Game.Screens;
-using Ionic.Zip;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -185,13 +185,10 @@ namespace GamesToGo.Game
         private void importGame(string zipName)
         {
             string filename = Path.Combine(@"download", @$"{zipName}.zip");
-
-            using (var fileStream = store.GetStream(store.GetFullPath(filename), FileAccess.Read, FileMode.Open))
+            using (ZipArchive zip = ZipFile.OpenRead(store.GetFullPath(filename)))
             {
-                using ZipFile zip = ZipFile.Read(fileStream);
-
-                foreach (ZipEntry e in zip)
-                    e.Extract(store.GetFullPath("files"), ExtractExistingFileAction.DoNotOverwrite);
+                foreach (ZipArchiveEntry e in zip.Entries)
+                    e.ExtractToFile(store.GetFullPath(Path.Combine("files", e.FullName)));
             }
 
             store.Delete(filename);


### PR DESCRIPTION
It would seem as DotNetZip is not exactly compatible with Release mode Xamarin applications, so changing to microsofts own zip reader should yield ok results in the meantime. 